### PR TITLE
Make info's phone optional

### DIFF
--- a/lib/omniauth/strategies/webex.rb
+++ b/lib/omniauth/strategies/webex.rb
@@ -30,7 +30,7 @@ module OmniAuth
           'nickname' => raw_info['nickName'],
           'first_name' => raw_info['firstName'],
           'last_name' => raw_info['lastName'],
-          'phone' => raw_info['phoneNumbers'].first
+          'phone' => raw_info['phoneNumbers']&.first
         }
       end
 


### PR DESCRIPTION
Description of the change
--------------------------

By making phoneNumbers optional, it avoids NoMethodError for nil:NilClass errors, from Webex accounts that do not have a phone number configured.

Type of change
----------------

- [X] Bug fix (non-breaking change that fixes an issue)